### PR TITLE
Support right context menu for MemoryView panel settings like visual studio memory view

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,11 +50,60 @@
     ],
     "main": "./dist/extension.js",
     "contributes": {
+        "menus": {
+            "webview/context": [
+                {
+                    "command": "memoryview.1_byte_Int_View",
+                    "when": "memoryview:showMemoryPanel && webviewSection == memorywebview_panel",
+                    "group": "1_settings@1"
+                },
+                {
+                    "command": "memoryview.4_byte_Int_View",
+                    "when": "memoryview:showMemoryPanel && webviewSection == memorywebview_panel",
+                    "group": "1_settings@2"
+                },
+                {
+                    "command": "memoryview.8_byte_Int_View",
+                    "when": "memoryview:showMemoryPanel && webviewSection == memorywebview_panel",
+                    "group": "1_settings@3"
+                },
+                {
+                    "command": "memoryview.Little_Endian_View",
+                    "when": "memoryview:showMemoryPanel && webviewSection == memorywebview_panel",
+                    "group": "3_settings@1"
+                },
+                {
+                    "command": "memoryview.Big_Endian_View",
+                    "when": "memoryview:showMemoryPanel && webviewSection == memorywebview_panel",
+                    "group": "3_settings@2"
+                }
+            ]
+        },
         "commands": [
             {
-                "category": "MemoryView",
-                "command": "Debugger.memoryview.hello",
-                "title": "Testing: Force 'memoryview' extension to load"
+                "category": "MemoryView_RightClickContextMenu",
+                "command": "memoryview.1_byte_Int_View",
+                "title": "1-Byte Integer View"
+            },
+            {
+                "category": "MemoryView_RightClickContextMenu",
+                "command": "memoryview.4_byte_Int_View",
+                "title": "4-Bytes Integer View"
+            },
+            {
+                "category": "MemoryView_RightClickContextMenu",
+                "command": "memoryview.8_byte_Int_View",
+                "title": "8-Bytes Integer View"
+            },
+            {
+                "category": "MemoryView_RightClickContextMenu",
+                "command": "memoryview.Little_Endian_View",
+                "title": "Little Endian"
+            },
+            {
+                "category": "MemoryView_RightClickContextMenu",
+                "command": "memoryview.Big_Endian_View",
+                "title": "Big Endian"
             },
             {
                 "category": "MemoryView",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import querystring from 'node:querystring';
 import { DebugTrackerFactory } from './extension/debugTracker';
 import { DebugTracker } from './debugTracker/exports';
 import { /*MemviewDocumentProvider, */ MemViewPanelProvider } from './extension/memviewDocument';
+import { registerCommands } from './extension/commmandRegistration';
 
 /**
  * It is best to add a new memory view when a debug session is active and in stopped
@@ -92,10 +93,14 @@ export class MemViewExtension {
         const debugTracker = new DebugTracker(context);
         this.tracker = DebugTrackerFactory.register(context, debugTracker);
         // MemviewDocumentProvider.register(context);
+
+        // intialize the memory view panel provider. MemViewPanelProvider.Provider
         MemViewPanelProvider.register(context);
 
         this.setContexts();
 
+        //
+        registerCommands(context, MemViewPanelProvider.Provider);
         context.subscriptions.push(
             vscode.commands.registerCommand('Debugger.memoryview.toggleMemoryView', this.toggleMemoryView.bind(this)),
             vscode.commands.registerCommand('Debugger.memoryview.uriTest', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import { DebugTrackerFactory } from './extension/debugTracker';
 import { DebugTracker } from './debugTracker/exports';
 import { /*MemviewDocumentProvider, */ MemViewPanelProvider } from './extension/memviewDocument';
 import { registerCommands } from './extension/commmandRegistration';
-
+import { MemviewUriOptions } from './extension/shared';
 /**
  * It is best to add a new memory view when a debug session is active and in stopped
  * status. Otherwise, there has to be a lot of guessing and we may not always get it right
@@ -15,41 +15,6 @@ import { registerCommands } from './extension/commmandRegistration';
  * future invocations and automatically bind to a new session. Of course, this can fail
  * if the session name changes or workspace folder changes.
  */
-export interface MemviewUriOptions {
-    /**
-     * `memoryReference` is what a debug adapter provides. It is an opaque string representing a location in memory.
-     * If this exists, we use it if the there is no `expr`, or if you have an `expr` as a fallback memory location.
-     * This is generally provided by automated tools and not something to be manually entered.
-     */
-    memoryReference?: string;
-
-    /**
-     * `expr` can be a constant memory address or an expression resulting in an address by debugger using evaluate().
-     * URI path is used if no expr is specified
-     */
-    expr?: string;
-
-    /**
-     * We try to derive most of the following if not specified. If sessionId is specified, it should
-     * be a currently running debugger (may not be active session). When we can't match the active
-     * debug session with what the sessionId given, we may defer to until later.
-     */
-    sessionId?: string | 'current'; // Undefined also means 'current' if there is an active session
-
-    /** If not supplied, use expr or the URI path */
-    displayName?: string;
-
-    /**
-     * Following to can be used for better matching of an inactive memory view with a later active
-     * debug session. Unfortunately, that only works when the debugger starts a new session
-     */
-
-    /** Session name for better matching with a future debug session. */
-    sessionName?: string;
-
-    /** Workspace folder associated with the debug session for better matching with a future debug session. */
-    wsFolder?: string; // Must be a Uri.toString() of an actual wsFolder for the session
-}
 
 export class MemViewExtension {
     static Extension: MemViewExtension;
@@ -99,44 +64,10 @@ export class MemViewExtension {
 
         this.setContexts();
 
-        //
-        registerCommands(context, MemViewPanelProvider.Provider);
+        // register the commands for the memoryview extensions.
+        registerCommands(context, MemViewPanelProvider.Provider, this.tracker);
+
         context.subscriptions.push(
-            vscode.commands.registerCommand('Debugger.memoryview.toggleMemoryView', this.toggleMemoryView.bind(this)),
-            vscode.commands.registerCommand('Debugger.memoryview.uriTest', () => {
-                const options: MemviewUriOptions = {
-                    expr: '&buf'
-                };
-                if (vscode.debug.activeDebugSession) {
-                    options.sessionId = vscode.debug.activeDebugSession.id;
-                }
-                const uri = vscode.Uri.from({
-                    scheme: vscode.env.uriScheme,
-                    authority: 'Debugger.memoryview',
-                    path: '/' + encodeURIComponent('&buf'),
-                    query: querystring.stringify(options as any)
-                });
-                console.log('Opening URI', uri.toString());
-                vscode.env.openExternal(uri).then((success: boolean) => {
-                    console.log(`Operation URI open: success=${success}`);
-                }),
-                    (e: any) => {
-                        console.error(e);
-                    };
-            }),
-            // The following will add a memory view. If no arguments are present then the user will be prompted for an expression
-            vscode.commands.registerCommand(
-                'Debugger.memoryview.addMemoryView',
-                (constOrExprOrMemRef?: string, opts?: MemviewUriOptions) => {
-                    if (this.tracker.isActive()) {
-                        MemViewPanelProvider.newMemoryView(constOrExprOrMemRef, opts);
-                    } else {
-                        vscode.window.showErrorMessage(
-                            'Cannot execute this command as the debug-tracker-vscode extension did not connect properly'
-                        );
-                    }
-                }
-            ),
             vscode.workspace.onDidChangeConfiguration(this.onSettingsChanged.bind(this)),
 
             /**

--- a/src/extension/commmandRegistration.ts
+++ b/src/extension/commmandRegistration.ts
@@ -1,0 +1,55 @@
+import * as vscode from 'vscode';
+import { MemViewPanelProvider } from './memviewDocument';
+import { EndianType, RowFormatType } from './shared';
+import { DualViewDoc } from './dualViewDoc';
+
+const OneByteIntMemoryViewPanelCommandName = 'memoryview.1_byte_Int_View';
+const FourBytesIntMemoryViewPanelCommandName = 'memoryview.4_byte_Int_View';
+const EightBytesIntMemoryViewPanelCommandName = 'memoryview.8_byte_Int_View';
+const LittleEndianMemoryViewPanelCommandName = 'memoryview.Little_Endian_View';
+const BigEndianMemoryViewPanelCommandName = 'memoryview.Big_Endian_View';
+
+export function registerCommands(
+    context: vscode.ExtensionContext,
+    memoryViewPanelProvider: MemViewPanelProvider
+): void {
+    rightClickContextMenuHandler(context, memoryViewPanelProvider);
+}
+
+function rightClickContextMenuHandler(context: vscode.ExtensionContext, memoryViewPanelProvider: MemViewPanelProvider) {
+    context.subscriptions.push(
+        vscode.commands.registerCommand(OneByteIntMemoryViewPanelCommandName, () => {
+            updateRowFormatTypeSettings(memoryViewPanelProvider, '1-byte');
+        }),
+        vscode.commands.registerCommand(FourBytesIntMemoryViewPanelCommandName, () => {
+            updateRowFormatTypeSettings(memoryViewPanelProvider, '4-byte');
+        }),
+        vscode.commands.registerCommand(EightBytesIntMemoryViewPanelCommandName, () => {
+            updateRowFormatTypeSettings(memoryViewPanelProvider, '8-byte');
+        }),
+        vscode.commands.registerCommand(LittleEndianMemoryViewPanelCommandName, () => {
+            updateEndianTypeSettings(memoryViewPanelProvider, 'little');
+        }),
+        vscode.commands.registerCommand(BigEndianMemoryViewPanelCommandName, () => {
+            updateEndianTypeSettings(memoryViewPanelProvider, 'big');
+        })
+    );
+}
+
+function updateRowFormatTypeSettings(memoryViewPanelProvider: MemViewPanelProvider, dataFormat: RowFormatType) {
+    // Check if the current document is already in the desired format
+    if (DualViewDoc.currentDoc?.format === dataFormat) {
+        return;
+    }
+
+    memoryViewPanelProvider.updateCurrentMemoryViewSettings(dataFormat, undefined);
+}
+
+function updateEndianTypeSettings(memoryViewPanelProvider: MemViewPanelProvider, endianType: EndianType) {
+    // Check if the current document is already in the desired format
+    if (DualViewDoc.currentDoc?.endian === endianType) {
+        return;
+    }
+
+    memoryViewPanelProvider.updateCurrentMemoryViewSettings(undefined, endianType);
+}

--- a/src/extension/memviewDocument.ts
+++ b/src/extension/memviewDocument.ts
@@ -3,7 +3,7 @@ import querystring from 'node:querystring';
 import { uuid } from 'uuidv4';
 import * as fs from 'fs';
 import { DocDebuggerStatus, DualViewDoc } from './dualViewDoc';
-import { MemViewExtension, MemviewUriOptions } from '../extension';
+import { MemViewExtension } from '../extension';
 import {
     IWebviewDocXfer,
     ICmdGetMemory,
@@ -22,7 +22,8 @@ import {
     UnknownDocId,
     IModifiableProps,
     RowFormatType,
-    EndianType
+    EndianType,
+    MemviewUriOptions
 } from './shared';
 import { DebuggerTrackerLocal, ITrackedDebugSession } from './debugTracker';
 import { DebugProtocol } from '@vscode/debugprotocol';

--- a/src/extension/shared.ts
+++ b/src/extension/shared.ts
@@ -2,6 +2,42 @@ import { IMemPages } from './dualViewDoc';
 
 export const UnknownDocId = 'Unknown';
 
+export interface MemviewUriOptions {
+    /**
+     * `memoryReference` is what a debug adapter provides. It is an opaque string representing a location in memory.
+     * If this exists, we use it if the there is no `expr`, or if you have an `expr` as a fallback memory location.
+     * This is generally provided by automated tools and not something to be manually entered.
+     */
+    memoryReference?: string;
+
+    /**
+     * `expr` can be a constant memory address or an expression resulting in an address by debugger using evaluate().
+     * URI path is used if no expr is specified
+     */
+    expr?: string;
+
+    /**
+     * We try to derive most of the following if not specified. If sessionId is specified, it should
+     * be a currently running debugger (may not be active session). When we can't match the active
+     * debug session with what the sessionId given, we may defer to until later.
+     */
+    sessionId?: string | 'current'; // Undefined also means 'current' if there is an active session
+
+    /** If not supplied, use expr or the URI path */
+    displayName?: string;
+
+    /**
+     * Following to can be used for better matching of an inactive memory view with a later active
+     * debug session. Unfortunately, that only works when the debugger starts a new session
+     */
+
+    /** Session name for better matching with a future debug session. */
+    sessionName?: string;
+
+    /** Workspace folder associated with the debug session for better matching with a future debug session. */
+    wsFolder?: string; // Must be a Uri.toString() of an actual wsFolder for the session
+}
+
 export enum CmdType {
     GetDocuments = 'GetDocuments',
     GetMemory = 'GetMemory',
@@ -69,7 +105,7 @@ export interface ICmdSetByte extends ICmdBase {
 }
 
 export interface IMemValue {
-    changed?: boolean;      // Changed on reload (different from edited)
+    changed?: boolean; // Changed on reload (different from edited)
     cur: number;
     orig: number;
     stale: boolean;
@@ -103,8 +139,8 @@ export interface ICmdSettingsChanged extends ICmdBase {
 export type ModifiedXferMap = { [addr: string]: number };
 export interface IWebviewDocXfer {
     docId: string;
-    sessionId: string;          // The debug session ID, also the document Id
-    sessionName: string;        // The debug session name
+    sessionId: string; // The debug session ID, also the document Id
+    sessionName: string; // The debug session name
     displayName: string;
     expr: string;
     wsFolder: string;
@@ -124,7 +160,14 @@ export interface ICmdClientState extends ICmdBase {
     state: { [key: string]: any };
 }
 
-export type CmdButtonName = 'close' | 'new' | 'select' | 'refresh' | 'settings' | 'copy-all-to-clipboard' | 'copy-all-to-file';
+export type CmdButtonName =
+    | 'close'
+    | 'new'
+    | 'select'
+    | 'refresh'
+    | 'settings'
+    | 'copy-all-to-clipboard'
+    | 'copy-all-to-file';
 export interface ICmdButtonClick extends ICmdBase {
     button: CmdButtonName;
 }

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -1,8 +1,7 @@
-
 export class Timekeeper {
     private start = Date.now();
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    constructor(public resetOnQuery = false) { }
+    constructor(public resetOnQuery = false) {}
 
     public deltaMs(): number {
         const now = Date.now();
@@ -25,4 +24,13 @@ export function bigIntMin(a: bigint, b: bigint) {
 
 export function bigIntMax(a: bigint, b: bigint) {
     return a > b ? a : b;
+}
+
+export function getNonce() {
+    let text = '';
+    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    for (let i = 0; i < 32; i++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return text;
 }

--- a/src/view/hexTableVirtual.tsx
+++ b/src/view/hexTableVirtual.tsx
@@ -329,7 +329,11 @@ export class HexTableVirtual2 extends React.Component<IHexTableVirtual, IHexTabl
                 `In HexTableView2.render(), rowHeight=${this.state.rowHeight}, toolbarHeight=${this.state.toolbarHeight} scrollTop=${this.state.scrollTop}`
             );
         return (
-            <div className='container' style={{ overflowX: 'visible' }}>
+            <div
+                className='container'
+                style={{ overflowX: 'visible' }}
+                data-vscode-context='{"webviewSection": "memorywebview_panel", "mouseCount": 4, "preventDefaultContextMenuItems": true}'
+            >
                 {/*<HexHeaderRow></HexHeaderRow>*/}
                 <InfiniteLoader
                     isItemLoaded={this.isItemLoadedFunc}


### PR DESCRIPTION
In this PR, I am supporting right click context menu with different view (1 byte/ 4 byte / 8 byte int ...). I also moved all the vscode.commands registration to a single file for code readability. 
<img width="1207" alt="Screenshot 2025-04-12 at 9 29 49 PM" src="https://github.com/user-attachments/assets/0f605aa3-de8d-4d28-8774-a4917f4155c6" />
