### PR TITLE
support 2 byte integer, 4 byte float and 8 byte float view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
                 "vscode-webview-tools": "^0.1.1"
             },
             "engines": {
-                "vscode": "^1.90.0"
+                "vscode": "^1.70.0"
             }
         },
         "node_modules/@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -58,14 +58,29 @@
                     "group": "1_settings@1"
                 },
                 {
-                    "command": "memoryview.4_byte_Int_View",
+                    "command": "memoryview.2_byte_Int_View",
                     "when": "memoryview:showMemoryPanel && webviewSection == memorywebview_panel",
                     "group": "1_settings@2"
                 },
                 {
-                    "command": "memoryview.8_byte_Int_View",
+                    "command": "memoryview.4_byte_Int_View",
                     "when": "memoryview:showMemoryPanel && webviewSection == memorywebview_panel",
                     "group": "1_settings@3"
+                },
+                {
+                    "command": "memoryview.8_byte_Int_View",
+                    "when": "memoryview:showMemoryPanel && webviewSection == memorywebview_panel",
+                    "group": "1_settings@4"
+                },
+                {
+                    "command": "memoryview.4_byte_Float_View",
+                    "when": "memoryview:showMemoryPanel && webviewSection == memorywebview_panel",
+                    "group": "2_settings@1"
+                },
+                {
+                    "command": "memoryview.8_byte_Float_View",
+                    "when": "memoryview:showMemoryPanel && webviewSection == memorywebview_panel",
+                    "group": "2_settings@2"
                 },
                 {
                     "command": "memoryview.Little_Endian_View",
@@ -83,17 +98,32 @@
             {
                 "category": "MemoryView_RightClickContextMenu",
                 "command": "memoryview.1_byte_Int_View",
-                "title": "1-Byte Integer View"
+                "title": "1-Byte Integer"
+            },
+            {
+                "category": "MemoryView_RightClickContextMenu",
+                "command": "memoryview.2_byte_Int_View",
+                "title": "2-Byte Integer"
             },
             {
                 "category": "MemoryView_RightClickContextMenu",
                 "command": "memoryview.4_byte_Int_View",
-                "title": "4-Bytes Integer View"
+                "title": "4-Bytes Integer"
             },
             {
                 "category": "MemoryView_RightClickContextMenu",
                 "command": "memoryview.8_byte_Int_View",
-                "title": "8-Bytes Integer View"
+                "title": "8-Bytes Integer"
+            },
+            {
+                "category": "MemoryView_RightClickContextMenu",
+                "command": "memoryview.4_byte_Float_View",
+                "title": "32-bit Floating Point"
+            },
+            {
+                "category": "MemoryView_RightClickContextMenu",
+                "command": "memoryview.8_byte_Float_View",
+                "title": "64-bit Floating Point"
             },
             {
                 "category": "MemoryView_RightClickContextMenu",

--- a/src/extension/commmandRegistration.ts
+++ b/src/extension/commmandRegistration.ts
@@ -10,8 +10,13 @@ const UriTestCommandName = 'Debugger.memoryview.uriTest';
 const AddMemViewPanelCommandName = 'Debugger.memoryview.addMemoryView';
 
 const OneByteIntMemoryViewPanelCommandName = 'memoryview.1_byte_Int_View';
+const TwoByteIntMemoryViewPanelCommandName = 'memoryview.2_byte_Int_View';
 const FourBytesIntMemoryViewPanelCommandName = 'memoryview.4_byte_Int_View';
 const EightBytesIntMemoryViewPanelCommandName = 'memoryview.8_byte_Int_View';
+
+const FourBytesFloatMemoryViewPanelCommandName='memoryview.4_byte_Float_View';
+const EightBytesFloatMemoryViewPanelCommandName='memoryview.8_byte_Float_View';
+
 const LittleEndianMemoryViewPanelCommandName = 'memoryview.Little_Endian_View';
 const BigEndianMemoryViewPanelCommandName = 'memoryview.Big_Endian_View';
 
@@ -62,11 +67,20 @@ function registerRightClickContextMenuCommands(
         vscode.commands.registerCommand(OneByteIntMemoryViewPanelCommandName, () => {
             updateRowFormatTypeSettings(memoryViewPanelProvider, '1-byte');
         }),
+        vscode.commands.registerCommand(TwoByteIntMemoryViewPanelCommandName, () => {
+            updateRowFormatTypeSettings(memoryViewPanelProvider, '2-byte');
+        }),
         vscode.commands.registerCommand(FourBytesIntMemoryViewPanelCommandName, () => {
             updateRowFormatTypeSettings(memoryViewPanelProvider, '4-byte');
         }),
         vscode.commands.registerCommand(EightBytesIntMemoryViewPanelCommandName, () => {
             updateRowFormatTypeSettings(memoryViewPanelProvider, '8-byte');
+        }),
+        vscode.commands.registerCommand(FourBytesFloatMemoryViewPanelCommandName, () => {
+            updateRowFormatTypeSettings(memoryViewPanelProvider, '4-byte-float');
+        }),
+        vscode.commands.registerCommand(EightBytesFloatMemoryViewPanelCommandName, () => {
+            updateRowFormatTypeSettings(memoryViewPanelProvider, '8-byte-float');
         }),
         vscode.commands.registerCommand(LittleEndianMemoryViewPanelCommandName, () => {
             updateEndianTypeSettings(memoryViewPanelProvider, 'little');

--- a/src/extension/shared.ts
+++ b/src/extension/shared.ts
@@ -112,8 +112,18 @@ export interface IMemValue {
     inRange: boolean;
 }
 
-export type RowFormatType = '1-byte' | '4-byte' | '8-byte';
+export type RowFormatType = '1-byte'| '2-byte' | '4-byte' | '8-byte' | '4-byte-float' | '8-byte-float';
 export type EndianType = 'little' | 'big';
+export type FormatByteNumber = 1 | 2 | 4 | 8;
+
+export const BytesPerWordForFormatType: Record<string, FormatByteNumber> = {
+  '1-byte': 1,
+  '2-byte': 2,
+  '4-byte': 4,
+  '8-byte': 8,
+  '4-byte-float': 4,
+  '8-byte-float': 8,
+};
 
 export interface IModifiableProps {
     expr: string;

--- a/src/view/index.css
+++ b/src/view/index.css
@@ -56,11 +56,23 @@ body {
     width: 3ch;
 }
 
+.hex-cell-value2 {
+    width: 6ch;
+}
+
 .hex-cell-value4 {
     width: 10ch;
 }
 
 .hex-cell-value8 {
+    width: 18ch;
+}
+
+.hex-cell-valueFloat32 {
+    width: 15ch;
+}
+
+.hex-cell-valueFloat64 {
     width: 18ch;
 }
 
@@ -218,7 +230,6 @@ body {
     margin-right: 1ch;
 }
 
-	
 .tooltip {
     background: var(--vscode-textBlockQuote-background);
     font-family: var(--vscode-editor-font-family);
@@ -231,4 +242,4 @@ body {
     left: 100px;
     top: -20px;
     z-index: 100;
-  }
+}

--- a/src/view/shared.ts
+++ b/src/view/shared.ts
@@ -1,9 +1,11 @@
 export interface IMemValue32or64 {
     cur: bigint;
     orig: bigint;
+    bufferCur: Uint8Array;
     changed: boolean;
     stale: boolean;
     invalid: boolean;
+    dataType: HexWordDataType;
 }
 
 const odStyleChars = [
@@ -44,6 +46,47 @@ const odStyleChars = [
 
 export const charCodesLookup: string[] = [];
 export const hexValuesLookup: string[] = [];
+
+export enum HexWordDataType {
+    Byte = 'Byte',
+    Int16 = 'Int16',
+    Int32 = 'Int32',
+    Int64 = 'Int64',
+    Float32 = 'Float32',
+    Float64 = 'Float64',
+  }
+
+export function getFloat32AsString(inputArray: Uint8Array, isLittleEndian: boolean): string {
+    if (inputArray && inputArray.length >= 4) {
+      const dataview = new DataView(inputArray.buffer);
+      const float32 = dataview.getFloat32(0, isLittleEndian);
+  
+      let float32String = float32.toString();
+      if (float32String !== 'NaN') {
+        float32String = float32.toPrecision(9).toString();
+      }
+  
+      return float32String;
+    }
+  
+    return 'NaN';
+}
+
+export function getFloat64AsString(inputArray: Uint8Array, isLittleEndian: boolean): string {
+    if (inputArray && inputArray.length >= 4) {
+      const dataview = new DataView(inputArray.buffer);
+      const float32 = dataview.getFloat64(0, isLittleEndian);
+  
+      let float32String = float32.toString();
+      if (float32String !== 'NaN') {
+        float32String = float32.toPrecision(9).toString();
+      }
+  
+      return float32String;
+    }
+  
+    return 'NaN';
+}
 
 let initializedCharCode = false;
 function initCharCodes(): void {


### PR DESCRIPTION
In this change, I am introducing following features - 

1. Allow user to view 2-byte integer values.
2. Allow user to view 4-byte float values.
3. Allow user to view 8-byte float values .

<img width="1220" alt="Screenshot 2025-04-20 at 11 10 40 PM" src="https://github.com/user-attachments/assets/93cf406b-5830-471d-9c33-77058c788c3e" />
<img width="1223" alt="Screenshot 2025-04-20 at 11 10 58 PM" src="https://github.com/user-attachments/assets/b49477ec-c45f-42cc-b23e-e1b0a1d34be8" />
